### PR TITLE
X86_64 Windows Support And Ergonomic Context Wrapper

### DIFF
--- a/src/arch/x86_64/init_win.s
+++ b/src/arch/x86_64/init_win.s
@@ -1,0 +1,45 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) 2015, Nathan Zadoks <nathan@nathan7.eu>
+// See the LICENSE file included in this distribution.
+
+//! initialise a new context
+//! arguments:
+//!  * rdi: stack pointer
+//!  * rsi: function pointer
+//!  * rdx: data pointer
+//!  * rcx: stack limit
+//!
+//! return values:
+//!  * rdi: new stack pointer
+
+// switch to the fresh stack
+xchg %rsp, %rdi
+
+// save the function pointer, data pointer, and stack limit, respectively
+pushq %rsi
+pushq %rdx
+pushq %rcx
+
+// save the return address, control flow continues at label 1
+call 1f
+// we arrive here once this context is reactivated (see swap.s)
+
+// restore the stack limit, data pointer, and function pointer, respectively
+//popq %fs:0x70
+add $$8, %rsp
+popq %rdi
+popq %rax
+
+// initialise the frame pointer
+movq $$0, %rbp
+
+// call the function pointer with the data pointer (rdi is the first argument)
+call *%rax
+
+// crash if it ever returns
+ud2
+
+1:
+  // save our neatly-setup new stack
+  xchg %rsp, %rdi
+  // back into Rust-land we go

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -15,6 +15,25 @@ pub struct Registers {
 }
 
 impl Registers {
+  #[cfg(windows)]
+  #[inline]
+  pub unsafe fn new<S, F>(stack: &mut S, f: F) -> Registers where S: Stack, F: FnOnce() {
+    let sp_limit = stack.limit();
+    let mut sp = stack.top() as *mut usize;
+    let f_ptr = push(&mut sp, f);
+
+    asm!(include_str!("init_win.s")
+          : "={rdi}"(sp)
+          : "{rdi}" (sp),
+            "{rsi}" (rust_trampoline::<F>),
+            "{rdx}" (f_ptr),
+            "{rcx}" (sp_limit)
+          :
+          : "volatile");
+    Registers { rsp: sp }
+  }
+
+  #[cfg(not(windows))]
   #[inline]
   pub unsafe fn new<S, F>(stack: &mut S, f: F) -> Registers where S: Stack, F: FnOnce() {
     let sp_limit = stack.limit();
@@ -29,13 +48,29 @@ impl Registers {
             "{rcx}" (sp_limit)
           :
           : "volatile");
-
     Registers { rsp: sp }
   }
 
+  #[cfg(not(windows))]
   #[inline(always)]
   pub unsafe fn swap(&mut self) {
     asm!(include_str!("swap.s")
+          :
+          : "{rdi}" (&mut self.rsp)
+          : "rax",   "rbx",   "rcx",   "rdx",   "rsi",   "rdi", //"rbp",   "rsp",
+            "r8",    "r9",    "r10",   "r11",   "r12",   "r13",   "r14",   "r15",
+            "xmm0",  "xmm1",  "xmm2",  "xmm3",  "xmm4",  "xmm5",  "xmm6",  "xmm7",
+            "xmm8",  "xmm9",  "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",
+            "xmm16", "xmm17", "xmm18", "xmm19", "xmm20", "xmm21", "xmm22", "xmm23", 
+            "xmm24", "xmm25", "xmm26", "xmm27", "xmm28", "xmm29", "xmm30", "xmm31"
+            "cc"
+          : "volatile");
+  }
+
+  #[cfg(windows)]
+  #[inline(always)]
+  pub unsafe fn swap(&mut self) {
+    asm!(include_str!("swap_win.s")
           :
           : "{rdi}" (&mut self.rsp)
           : "rax",   "rbx",   "rcx",   "rdx",   "rsi",   "rdi", //"rbp",   "rsp",

--- a/src/arch/x86_64/swap_win.s
+++ b/src/arch/x86_64/swap_win.s
@@ -1,0 +1,47 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) 2015, Nathan Zadoks <nathan@nathan7.eu>
+// See the LICENSE file included in this distribution.
+
+//! switch to a new context
+//! arguments:
+//!  * rdi: stack pointer pointer
+
+// make sure we leave the red zone alone
+sub $$128, %rsp
+
+// save the Rust stack limit and the frame pointer, respectively
+//pushq %fs:0x70
+sub $$8, %rsp
+pushq %rbp
+
+// save the return address to the stack, control flow continues at label 1
+call 1f
+// we arrive here once this context is reactivated
+
+// restore the frame pointer and the Rust stack limit, respectively
+popq %rbp
+// popq %fs:0x70
+add $$8, %rsp
+
+// give back the red zone
+add $$128, %rsp
+
+// and we merrily go on our way, back into Rust-land
+jmp 2f
+
+1:
+  // retrieve the new stack pointer
+  movq (%rdi), %rax
+  // save the old stack pointer
+  movq %rsp, (%rdi)
+  // switch to the new stack pointer
+  movq %rax, %rsp
+
+  // jump into the new context (return to the call point)
+  // doing this instead of a straight `ret` is 8ns faster,
+  // presumably because the branch predictor tries
+  // to be clever about it otherwise
+  popq %rax
+  jmpq *%rax
+
+2:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(no_std)]
 #![feature(asm, core)]
 #![feature(alloc)]
+#![feature(thread_local)]
 #![no_std]
 
 //! libfringe is a low-level green threading library.
@@ -22,12 +23,19 @@ extern crate std;
 #[macro_use]
 extern crate std;
 
-
 pub use context::Context;
 pub use stack::Stack;
 
 #[cfg(feature = "os")]
 pub use os::Stack as OsStack;
+
+#[cfg(windows)]
+#[cfg(feature = "os")]
+pub use osfiber::Fiber as OsFiber;
+
+#[cfg(feature = "os")]
+#[cfg(windows)]
+mod osfiber;
 
 mod context;
 mod stack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // See the LICENSE file included in this distribution.
 #![feature(no_std)]
 #![feature(asm, core)]
+#![feature(alloc)]
 #![no_std]
 
 //! libfringe is a low-level green threading library.
@@ -12,8 +13,15 @@
 extern crate core;
 
 #[cfg(test)]
+#[cfg(not(windows))]
 #[macro_use]
 extern crate std;
+
+#[cfg(not(test))]
+#[cfg(windows)]
+#[macro_use]
+extern crate std;
+
 
 pub use context::Context;
 pub use stack::Stack;
@@ -31,4 +39,5 @@ mod arch;
 mod debug;
 
 #[cfg(not(test))]
+#[cfg(not(windows))]
 mod std { pub use core::*; }

--- a/src/os/sys/mod.rs
+++ b/src/os/sys/mod.rs
@@ -10,6 +10,10 @@ use self::imp::sys_page_size;
 #[path = "unix.rs"]
 mod imp;
 
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod imp;
+
 static PAGE_SIZE_CACHE: AtomicUsize = ATOMIC_USIZE_INIT;
 pub fn page_size() -> usize {
   match PAGE_SIZE_CACHE.load(Ordering::Relaxed) {

--- a/src/os/sys/windows.rs
+++ b/src/os/sys/windows.rs
@@ -1,0 +1,36 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) 2015, Nathan Zadoks <nathan@nathan7.eu>
+// See the LICENSE file included in this distribution.
+extern crate libc;
+extern crate std;
+
+use core::prelude::*;
+//use self::libc::{c_void, c_int, size_t};
+//use super::page_size;
+use self::std::rt::heap::{allocate, deallocate};
+
+//use core::ptr;
+
+#[cold]
+pub fn sys_page_size() -> usize {
+  4096 as usize
+}
+
+pub unsafe fn map_stack(len: usize) -> Option<*mut u8> {
+  let ptr = allocate(len, 8);
+  if !ptr.is_null() {
+    Some(ptr as *mut u8)
+  }
+  else {
+    None
+  }
+}
+
+pub unsafe fn protect_stack(_: *mut u8) -> bool {
+  true
+}
+
+pub unsafe fn unmap_stack(ptr: *mut u8, len: usize) -> bool {
+  deallocate(ptr, len, 8);
+  true
+}

--- a/src/osfiber.rs
+++ b/src/osfiber.rs
@@ -1,0 +1,98 @@
+//! Provides ergonomic usage of context with an OS type stack.
+//!
+//! The following is an example usage:
+//!
+//!    #![feature(thread_local)]
+//!    #![feature(asm)]
+//!    extern crate fringe;
+//!
+//!    use fringe::Context;
+//!    use std::mem::transmute;
+//!    use fringe::OsFiber;
+//!
+//!    fn test() {
+//!        println!("it's alive!");
+//!        OsFiber::pause();
+//!        println!("its alive again!");
+//!        OsFiber::pause();
+//!    }
+//!
+//!    fn main() {
+//!
+//!        let mut v: Vec<OsFiber> = Vec::new();
+//!
+//!
+//!        for x in 0..1 {
+//!            let stack = fringe::OsStack::new(4096).unwrap();
+//!            println!("making context");
+//!            let mut ctx = OsFiber::new(stack, move || {
+//!                // There is a crash if we try to call a non-closure
+//!                // function directly. Until it is fixed this will
+//!                // work for calling non-closure functions.
+//!                test();
+//!            });
+//!            v.push(ctx);
+//!        }
+//!
+//!        loop {
+//!            println!("resuming");
+//!            for ctx in v.iter_mut() {
+//!                ctx.resume();
+//!            }
+//!        }
+//!    }
+
+use core::prelude::*;
+use super::Context;
+use super::OsStack;
+use std::mem::transmute;
+
+#[thread_local]
+static mut cur_fiber: *mut Fiber<'static> = 0 as *mut Fiber;
+
+pub struct Fiber<'a> {
+    pub dead:       bool,
+    pub context:    Context<'a, OsStack>,
+}
+
+impl<'a> Fiber<'a> {
+    pub fn pause() {
+        unsafe {
+            if !cur_fiber.is_null() {
+                (*cur_fiber).context.swap();
+            }
+        }
+    }
+
+    pub fn resume(&mut self) -> bool {
+        unsafe {
+            if self.dead {
+                // Let the caller know we are done.
+                return true;
+            } else {
+                cur_fiber = transmute(self);
+                (*cur_fiber).context.swap();
+                // Let the caller know if we have completed.
+                (*cur_fiber).dead
+            }
+        }
+    }
+
+    pub fn new<'b, F>(stack: OsStack, f: F) -> Fiber<'b> where F: FnOnce() + Send + 'b {
+        unsafe {
+            let wf = move || {
+                f();
+                // Force a swap back to not require the `f` function
+                // to have to be explicit about returning control and
+                // risking a CPU exception to the whole program, and
+                // also mark us as dead.
+                (*cur_fiber).dead = true;
+                (*cur_fiber).context.swap();
+            };
+                Fiber {
+                dead:           false,
+               context:        Context::new(stack, wf),
+            }
+        }
+    }
+}


### PR DESCRIPTION
I think it may be desirable to use direct memory page allocation for Windows, but this was the easiest and fastest way to get support working. If you do not merge it then maybe you can at least see what needs to be done in order to support Windows.