### PR TITLE
Remove unnecessary unsafety

### DIFF
--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -14,7 +14,7 @@ mod imp {
   pub struct StackId;
   /// No-op since no valgrind
   impl StackId {
-    pub unsafe fn register<Stack: stack::Stack>(_stack: &mut Stack) -> StackId {
+    pub fn register<Stack: stack::Stack>(_stack: &mut Stack) -> StackId {
       StackId
     }
   }


### PR DESCRIPTION
Unless I am missing something, the Valgrind version isn't unsafe either, so this makes it consistent too.

This is the last trivial PR "warming up" to my more major changes. I figured it would be good to do these separately to minimize diff on those.