### PR TITLE
add Windows support to OsStack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ authors = ["Nathan Zadoks <nathan@nathan7.eu>"]
 name = "fringe"
 version = "0.0.1"
 
+[dependencies.kernel32-sys]
+optional = true
+version = "0.2.2"
+
 [dependencies.libc]
 optional = true
 version = "0.1.6"
@@ -16,6 +20,10 @@ rev = "7aa8b3fcd3b19994c4669cabc6eae1f96882729d"
 default-features = false
 version = "1"
 
+[dependencies.winapi]
+optional = true
+version = "0.2.6"
+
 [features]
 default = ["os", "valgrind"]
-os = ["libc"]
+os = ["libc", "kernel32-sys", "winapi"]

--- a/src/os/sys/mod.rs
+++ b/src/os/sys/mod.rs
@@ -10,6 +10,10 @@ use self::imp::sys_page_size;
 #[path = "unix.rs"]
 mod imp;
 
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod imp;
+
 static PAGE_SIZE_CACHE: AtomicUsize = ATOMIC_USIZE_INIT;
 pub fn page_size() -> usize {
   match PAGE_SIZE_CACHE.load(Ordering::Relaxed) {

--- a/src/os/sys/windows.rs
+++ b/src/os/sys/windows.rs
@@ -1,0 +1,37 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) Nathan Zadoks <nathan@nathan7.eu>
+// See the LICENSE file included in this distribution.
+extern crate winapi;
+extern crate kernel32;
+use core::{mem, ptr};
+use self::winapi::basetsd::SIZE_T;
+use self::winapi::minwindef::{DWORD, LPVOID};
+use self::winapi::winnt::{MEM_COMMIT, MEM_RESERVE, MEM_RELEASE, PAGE_READWRITE, PAGE_NOACCESS};
+use super::page_size;
+
+#[cfg(windows)]
+pub fn sys_page_size() -> usize {
+  unsafe {
+    let mut info = mem::zeroed();
+    kernel32::GetSystemInfo(&mut info);
+    info.dwPageSize as usize
+  }
+}
+
+pub unsafe fn map_stack(len: usize) -> Option<*mut u8> {
+  let ptr = kernel32::VirtualAlloc(ptr::null_mut(), len as SIZE_T, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  if ptr == ptr::null_mut() {
+    None
+  } else {
+    Some(ptr as *mut u8)
+  }
+}
+
+pub unsafe fn protect_stack(ptr: *mut u8) -> bool {
+  let mut old_prot: DWORD = 0;
+  kernel32::VirtualProtect(ptr as LPVOID, page_size() as SIZE_T, PAGE_NOACCESS, &mut old_prot) != 0
+}
+
+pub unsafe fn unmap_stack(ptr: *mut u8, _len: usize) -> bool {
+  kernel32::VirtualFree(ptr as LPVOID, 0, MEM_RELEASE) != 0
+}


### PR DESCRIPTION
Currently pending a fresh kernel32-sys cargo publish, since the version on crates.io right now has a broken signature for VirtualProtect.