### PR TITLE
Use consistent register names where free, and make trampoline its own function

### DIFF
--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -81,7 +81,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer)
       # Remember stack pointer of the old context, in case %rdx==%rsi.
       movl    %esp, %ebx
       # Load stack pointer of the new context.
-      movl    (%edi), %esp
+      movl    (%edx), %esp
       # Save stack pointer of the old context.
       movl    %ebx, (%esi)
 
@@ -95,7 +95,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer)
     : "={eax}" (ret)
     : "{eax}" (arg)
       "{esi}" (old_sp)
-      "{edi}" (new_sp)
+      "{edx}" (new_sp)
     : "eax",  "ebx",  "ecx",  "edx",  "esi",  "edi", //"ebp",  "esp",
       "mmx0", "mmx1", "mmx2", "mmx3", "mmx4", "mmx5", "mmx6", "mmx7",
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -58,17 +58,17 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer)
 
     1:
       # Remember stack pointer of the old context, in case %rdx==%rsi.
-      movq    %rsp, %rax
+      movq    %rsp, %rbx
       # Load stack pointer of the new context.
       movq    (%rdx), %rsp
       # Save stack pointer of the old context.
-      movq    %rax, (%rsi)
+      movq    %rbx, (%rsi)
 
       # Pop instruction pointer of the new context (placed onto stack by
       # the call above) and jump there; don't use `ret` to avoid return
       # address mispredictions (~8ns on Ivy Bridge).
-      popq    %rax
-      jmpq    *%rax
+      popq    %rbx
+      jmpq    *%rbx
     2:
     "#
     : "={rdi}" (ret)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright (c) Nathan Zadoks <nathan@nathan7.eu>
 // See the LICENSE file included in this distribution.
 #![feature(asm)]
+#![cfg_attr(target_arch = "x86", feature(naked_functions, core_intrinsics))]
 #![no_std]
 
 //! libfringe is a low-level green threading library.


### PR DESCRIPTION
Ok, now things get interesting. These changes don't affect the context interface at all, but change the assembly such that I can do my parameter/coroutine stuff too. I hope after this to refactor that work so it can be added to this crate without touching the context interface interfaces.

Feel free to ask any questions about why things are changed the way they are, of course :).