### PR TITLE
Allocate guard page under existing stack, not in it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "fringe"
 version = "0.0.1"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.1.6"
+libc = "0.2.14"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,13 +6,13 @@ use stack;
 use debug;
 use arch;
 
-/// Context is the heart of libfringe.
-/// A context represents a saved thread of execution, along with a stack.
+/// Context holds a suspended thread of execution along with a stack.
+///
 /// It can be swapped into and out of with the swap method,
 /// and once you're done with it, you can get the stack back through unwrap.
 ///
-/// Every operation is unsafe, because libfringe can't make any guarantees
-/// about the state of the context.
+/// Every operation is unsafe, because no guarantees can be made about
+/// the state of the context.
 #[derive(Debug)]
 pub struct Context<Stack: stack::Stack> {
   stack:     Stack,
@@ -24,7 +24,7 @@ unsafe impl<Stack> Send for Context<Stack>
   where Stack: stack::Stack + Send {}
 
 impl<Stack> Context<Stack> where Stack: stack::Stack {
-  /// Create a new Context. When it is swapped into, it will call
+  /// Creates a new Context. When it is swapped into, it will call
   /// `f(arg)`, where `arg` is the argument passed to `swap`.
   pub unsafe fn new(stack: Stack, f: unsafe extern "C" fn(usize) -> !) -> Context<Stack> {
     let stack_id  = debug::StackId::register(&stack);
@@ -36,14 +36,14 @@ impl<Stack> Context<Stack> where Stack: stack::Stack {
     }
   }
 
-  /// Unwrap the context, returning the stack it contained.
+  /// Unwraps the context, returning the stack it contained.
   pub unsafe fn unwrap(self) -> Stack {
     self.stack
   }
 }
 
 impl<OldStack> Context<OldStack> where OldStack: stack::Stack {
-  /// Switch to in_ctx, saving the current thread of execution to out_ctx.
+  /// Switches to in_ctx, saving the current thread of execution to out_ctx.
   #[inline(always)]
   pub unsafe fn swap<NewStack>(old_ctx: *mut Context<OldStack>,
                                new_ctx: *const Context<NewStack>,

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -7,8 +7,9 @@ use stack;
 
 mod sys;
 
-/// This object represents a stack from the operating system's
-/// anonymous memory mapping facility, usually `mmap`.
+/// OsStack holds a stack allocated using the operating system's anonymous
+/// memory mapping facility.
+///
 /// The stack it provides comes with a guard page, which is not included
 /// in the stack limit.
 #[derive(Debug)]
@@ -20,6 +21,10 @@ pub struct Stack {
 unsafe impl Send for Stack {}
 
 impl Stack {
+  /// Allocates a new stack with at least `size` accessible bytes.
+  /// `size` is rounded up to an integral number of pages; `Stack::new(0)`
+  /// is legal and allocates the smallest possible stack, consisting
+  /// of one data page and one guard page.
   pub fn new(size: usize) -> Result<Stack, IoError> {
     let page_size = sys::page_size();
 

--- a/src/os/sys/unix.rs
+++ b/src/os/sys/unix.rs
@@ -1,7 +1,9 @@
 // This file is part of libfringe, a low-level green threading library.
 // Copyright (c) Nathan Zadoks <nathan@nathan7.eu>
 // See the LICENSE file included in this distribution.
+extern crate std;
 extern crate libc;
+use self::std::io::Error as IoError;
 use self::libc::{c_void, c_int, size_t};
 use self::libc::{mmap, mprotect, munmap};
 use self::libc::MAP_FAILED;
@@ -29,20 +31,27 @@ const STACK_FLAGS: c_int = libc::MAP_STACK
 const STACK_FLAGS: c_int = libc::MAP_PRIVATE
                          | libc::MAP_ANON;
 
-pub unsafe fn map_stack(len: usize) -> Option<*mut u8> {
-  let ptr = mmap(ptr::null_mut(), len as size_t,
-                 STACK_PROT, STACK_FLAGS, -1, 0);
+pub unsafe fn map_stack(len: usize) -> Result<*mut u8, IoError> {
+  let ptr = mmap(ptr::null_mut(), len as size_t, STACK_PROT, STACK_FLAGS, -1, 0);
   if ptr == MAP_FAILED {
-    None
+    Err(IoError::last_os_error())
   } else {
-    Some(ptr as *mut u8)
+    Ok(ptr as *mut u8)
   }
 }
 
-pub unsafe fn protect_stack(ptr: *mut u8) -> bool {
-  mprotect(ptr as *mut c_void, page_size() as size_t, GUARD_PROT) == 0
+pub unsafe fn protect_stack(ptr: *mut u8) -> Result<(), IoError> {
+  if mprotect(ptr as *mut c_void, page_size() as size_t, GUARD_PROT) == 0 {
+    Ok(())
+  } else {
+    Err(IoError::last_os_error())
+  }
 }
 
-pub unsafe fn unmap_stack(ptr: *mut u8, len: usize) -> bool {
-  munmap(ptr as *mut c_void, len as size_t) == 0
+pub unsafe fn unmap_stack(ptr: *mut u8, len: usize) -> Result<(), IoError> {
+  if munmap(ptr as *mut c_void, len as size_t) == 0 {
+    Ok(())
+  } else {
+    Err(IoError::last_os_error())
+  }
 }

--- a/src/os/sys/windows.rs
+++ b/src/os/sys/windows.rs
@@ -1,15 +1,17 @@
 // This file is part of libfringe, a low-level green threading library.
 // Copyright (c) Nathan Zadoks <nathan@nathan7.eu>
 // See the LICENSE file included in this distribution.
+extern crate std;
 extern crate winapi;
 extern crate kernel32;
-use core::{mem, ptr};
+use self::std::io::Error as IoError;
+use self::std::{mem, ptr};
 use self::winapi::basetsd::SIZE_T;
 use self::winapi::minwindef::{DWORD, LPVOID};
 use self::winapi::winnt::{MEM_COMMIT, MEM_RESERVE, MEM_RELEASE, PAGE_READWRITE, PAGE_NOACCESS};
 use super::page_size;
 
-#[cfg(windows)]
+#[cold]
 pub fn sys_page_size() -> usize {
   unsafe {
     let mut info = mem::zeroed();
@@ -18,20 +20,30 @@ pub fn sys_page_size() -> usize {
   }
 }
 
-pub unsafe fn map_stack(len: usize) -> Option<*mut u8> {
-  let ptr = kernel32::VirtualAlloc(ptr::null_mut(), len as SIZE_T, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+pub unsafe fn map_stack(len: usize) -> Result<*mut u8, IoError> {
+  let ptr = kernel32::VirtualAlloc(ptr::null_mut(), len as SIZE_T,
+                                   MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
   if ptr == ptr::null_mut() {
-    None
+    Err(IoError::last_os_error())
   } else {
-    Some(ptr as *mut u8)
+    Ok(ptr as *mut u8)
   }
 }
 
-pub unsafe fn protect_stack(ptr: *mut u8) -> bool {
+pub unsafe fn protect_stack(ptr: *mut u8) -> Result<(), IoError> {
   let mut old_prot: DWORD = 0;
-  kernel32::VirtualProtect(ptr as LPVOID, page_size() as SIZE_T, PAGE_NOACCESS, &mut old_prot) != 0
+  if kernel32::VirtualProtect(ptr as LPVOID, page_size() as SIZE_T,
+                              PAGE_NOACCESS, &mut old_prot) == 0 {
+    Err(IoError::last_os_error())
+  } else {
+    Ok(())
+  }
 }
 
-pub unsafe fn unmap_stack(ptr: *mut u8, _len: usize) -> bool {
-  kernel32::VirtualFree(ptr as LPVOID, 0, MEM_RELEASE) != 0
+pub unsafe fn unmap_stack(ptr: *mut u8, _len: usize) -> Result<(), IoError> {
+  if kernel32::VirtualFree(ptr as LPVOID, 0, MEM_RELEASE) == 0 {
+    Err(IoError::last_os_error())
+  } else {
+    Ok(())
+  }
 }

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -1,0 +1,13 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) whitequark <whitequark@whitequark.org>
+// See the LICENSE file included in this distribution.
+extern crate fringe;
+
+use fringe::{Stack, OsStack};
+
+#[test]
+fn stack_accessible() {
+  let stack = OsStack::new(4096).unwrap();
+  // Make sure the topmost page of the stack, at least, is accessible.
+  unsafe { *(stack.top().offset(-1)) = 0; }
+}


### PR DESCRIPTION
This fixes a segfault when the allocated stack is just one page long, and adds a test. Allocating a stack one page long was legal according to the documentation and it would be accessible, but what happened is a stack one page long was allocated and that one page was marked as guard page (instead of one page under the entire useful stack area).

This also refactors the fringe::os module to use Result consistently.