### PR TITLE
Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ rust: nightly
 sudo: false
 install:
   - .travis/docs/install
-script: 
-  - cargo build --verbose
+script:
+  - cargo rustc --verbose -- -C llvm-args=-verify-machineinstrs
   - cargo test --verbose
   - cargo bench --verbose
   - cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ rev = "7aa8b3fcd3b19994c4669cabc6eae1f96882729d"
 simd = "0.1"
 
 [features]
-default = ["valgrind"]
+default = ["alloc", "valgrind"]
+alloc = []
 
 # These apply only to tests within this library; assembly at -O0 is completely
 # unreadable, so use -O1.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ It provides the following safe abstractions:
 It also provides the necessary low-level building blocks:
   * a trait that can be implemented by stack allocators,
     [Stack](https://nathan7.github.io/libfringe/fringe/struct.Stack.html);
+  * a wrapper for using slice references as stacks,
+    [SliceStack](https://nathan7.github.io/libfringe/fringe/struct.SliceStack.html);
+  * a stack allocator based on `Box<[u8]>`,
+    [OwnedStack](https://nathan7.github.io/libfringe/fringe/struct.OwnedStack.html);
   * a stack allocator based on anonymous memory mappings with guard pages,
     [OsStack](https://nathan7.github.io/libfringe/fringe/struct.OsStack.html).
 
@@ -136,10 +140,16 @@ no-default-features = true
 libfringe provides some optional features through [Cargo's feature flags].
 Currently, all of them are enabled by default.
 
+#### `alloc`
+
+This flag enables dependency on the `alloc` crate, which is required for
+the [OwnedStack](https://nathan7.github.io/libfringe/fringe/struct.OwnedStack.html).
+
 #### `valgrind`
 
+This flag enables [Valgrind] integration. libfringe will register context stacks with Valgrind.
+
 [Valgrind]: http://valgrind.org
-[Valgrind] integration. libfringe will register context stacks with Valgrind.
 
 ## Internals
 

--- a/benches/generator.rs
+++ b/benches/generator.rs
@@ -14,7 +14,7 @@ use fringe::{OsStack, Generator};
 fn generate(b: &mut test::Bencher) {
   let stack = OsStack::new(0).unwrap();
   let mut identity = Generator::new(stack, move |yielder, mut input| {
-    loop { input = yielder.generate(input) }
+    loop { input = yielder.suspend(input) }
   });
 
   b.iter(|| test::black_box(identity.resume(test::black_box(0))));

--- a/src/arch/or1k.rs
+++ b/src/arch/or1k.rs
@@ -156,7 +156,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer,
       "{r4}" (old_sp)
       "{r5}" (new_sp)
       "{r6}" (new_cfa)
-    :                      "r3",  "r4",  "r5",  "r6",  "r7",
+    :/*"r0", "r1",  "r2",  "r3",  "r4",  "r5",  "r6",*/"r7",
       "r8",  "r9",  "r10", "r11", "r12", "r13", "r14", "r15",
       "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23",
       "r24", "r25", "r26", "r27", "r28", "r29", "r30", "r31",

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -151,7 +151,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer,
       "{esi}" (old_sp)
       "{edx}" (new_sp)
       "{edi}" (new_cfa)
-    : "eax",  "ebx",  "ecx",  "edx",  "esi",  "edi", //"ebp",  "esp",
+    :/*"eax",*/"ebx",  "ecx",/*"edx",  "esi",  "edi", "ebp",  "esp",*/
       "mmx0", "mmx1", "mmx2", "mmx3", "mmx4", "mmx5", "mmx6", "mmx7",
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
       "cc", "fpsr", "flags", "memory"

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -153,7 +153,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer,
       "{rsi}" (old_sp)
       "{rdx}" (new_sp)
       "{rcx}" (new_cfa)
-    : "rax",   "rbx",   "rcx",   "rdx",   "rsi",   "rdi", //"rbp",   "rsp",
+    : "rax",   "rbx", /*"rcx",   "rdx",   "rsi",   "rdi",   "rbp",   "rsp",*/
       "r8",    "r9",    "r10",   "r11",   "r12",   "r13",   "r14",   "r15",
       "xmm0",  "xmm1",  "xmm2",  "xmm3",  "xmm4",  "xmm5",  "xmm6",  "xmm7",
       "xmm8",  "xmm9",  "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 #![feature(asm, naked_functions)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(test, feature(test, thread_local, const_fn))]
 #![no_std]
 
@@ -21,6 +22,10 @@
 //!
 //!   * a trait that can be implemented by stack allocators,
 //!     [Stack](struct.Stack.html);
+//!   * a wrapper for using slice references as stacks,
+//!     [SliceStack](struct.SliceStack.html);
+//!   * a stack allocator based on `Box<[u8]>`,
+//!     [OwnedStack](struct.OwnedStack.html);
 //!   * a stack allocator based on anonymous memory mappings with guard pages,
 //!     [OsStack](struct.OsStack.html).
 
@@ -30,9 +35,11 @@ extern crate std;
 
 pub use stack::Stack;
 pub use stack::GuardedStack;
-pub use stack::SliceStack;
-
+pub use slice_stack::SliceStack;
 pub use generator::Generator;
+
+#[cfg(feature = "alloc")]
+pub use owned_stack::OwnedStack;
 
 #[cfg(unix)]
 pub use os::Stack as OsStack;
@@ -40,9 +47,13 @@ pub use os::Stack as OsStack;
 mod arch;
 mod debug;
 
-mod stack;
 mod context;
+mod stack;
+mod slice_stack;
 pub mod generator;
+
+#[cfg(feature = "alloc")]
+mod owned_stack;
 
 #[cfg(unix)]
 mod os;

--- a/src/owned_stack.rs
+++ b/src/owned_stack.rs
@@ -7,6 +7,7 @@ use self::alloc::raw_vec::RawVec;
 use self::alloc::boxed::Box;
 
 /// OwnedStack allocates on heap and owns a non-guarded stack.
+#[derive(Debug)]
 pub struct OwnedStack(Box<[u8]>);
 
 impl OwnedStack {

--- a/src/owned_stack.rs
+++ b/src/owned_stack.rs
@@ -1,0 +1,33 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) whitequark <whitequark@whitequark.org>
+// See the LICENSE file included in this distribution.
+extern crate alloc;
+
+use self::alloc::raw_vec::RawVec;
+use self::alloc::boxed::Box;
+
+/// OwnedStack allocates on heap and owns a non-guarded stack.
+pub struct OwnedStack(Box<[u8]>);
+
+impl OwnedStack {
+    /// Allocates a new stack with exactly `size` accessible bytes using
+    /// the default Rust allocator.
+    pub fn new(size: usize) -> OwnedStack {
+        OwnedStack(unsafe { RawVec::with_capacity(size).into_box() })
+    }
+}
+
+impl ::stack::Stack for OwnedStack {
+    #[inline(always)]
+    fn base(&self) -> *mut u8 {
+        // The slice cannot wrap around the address space, so the conversion from usize
+        // to isize will not wrap either.
+        let len: isize = self.0.len() as isize;
+        unsafe { self.limit().offset(len) }
+    }
+
+    #[inline(always)]
+    fn limit(&self) -> *mut u8 {
+        self.0.as_ptr() as *mut u8
+    }
+}

--- a/src/slice_stack.rs
+++ b/src/slice_stack.rs
@@ -4,6 +4,7 @@
 
 /// SliceStack holds a non-guarded stack allocated elsewhere and provided as a mutable
 /// slice.
+#[derive(Debug)]
 pub struct SliceStack<'a>(pub &'a mut [u8]);
 
 impl<'a> ::stack::Stack for SliceStack<'a> {

--- a/src/slice_stack.rs
+++ b/src/slice_stack.rs
@@ -1,0 +1,22 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) whitequark <whitequark@whitequark.org>
+// See the LICENSE file included in this distribution.
+
+/// SliceStack holds a non-guarded stack allocated elsewhere and provided as a mutable
+/// slice.
+pub struct SliceStack<'a>(pub &'a mut [u8]);
+
+impl<'a> ::stack::Stack for SliceStack<'a> {
+    #[inline(always)]
+    fn base(&self) -> *mut u8 {
+        // The slice cannot wrap around the address space, so the conversion from usize
+        // to isize will not wrap either.
+        let len: isize = self.0.len() as isize;
+        unsafe { self.limit().offset(len) }
+    }
+
+    #[inline(always)]
+    fn limit(&self) -> *mut u8 {
+        self.0.as_ptr() as *mut u8
+    }
+}

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -4,6 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+//! Traits for stacks.
 
 /// A trait for objects that hold ownership of a stack.
 pub trait Stack {
@@ -22,22 +23,3 @@ pub trait Stack {
 /// A guarded stack must guarantee that any access of data at addresses `limit()` to
 /// `limit().offset(4096)` will abnormally terminate the program.
 pub unsafe trait GuardedStack {}
-
-/// SliceStack holds a non-guarded stack allocated elsewhere and provided as a mutable
-/// slice.
-pub struct SliceStack<'a>(pub &'a mut [u8]);
-
-impl<'a> Stack for SliceStack<'a> {
-    #[inline(always)]
-    fn base(&self) -> *mut u8 {
-        // The slice cannot wrap around the address space, so the conversion from usize
-        // to isize will not wrap either.
-        let len: isize = self.0.len() as isize;
-        unsafe { self.limit().offset(len) }
-    }
-
-    #[inline(always)]
-    fn limit(&self) -> *mut u8 {
-        self.0.as_ptr() as *mut u8
-    }
-}

--- a/tests/fpe.rs
+++ b/tests/fpe.rs
@@ -24,7 +24,7 @@ extern {
 fn fpe() {
   let stack = OsStack::new(0).unwrap();
   let mut gen = Generator::new(stack, move |yielder, ()| {
-    yielder.generate(1.0 / black_box(0.0));
+    yielder.suspend(1.0 / black_box(0.0));
   });
 
   unsafe { feenableexcept(FE_DIVBYZERO); }

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -14,7 +14,7 @@ fn new_add_one() -> Generator<i32, i32, OsStack> {
   Generator::new(stack, move |yielder, mut input| {
     loop {
       if input == 0 { break }
-      input = yielder.generate(input + 1)
+      input = yielder.suspend(input + 1)
     }
   })
 }
@@ -71,7 +71,7 @@ fn with_slice_stack() {
     Generator::unsafe_new(stack, move |yielder, mut input| {
       loop {
         if input == 0 { break }
-        input = yielder.generate(input + 1)
+        input = yielder.suspend(input + 1)
       }
     })
   };

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -13,7 +13,7 @@ use fringe::generator::Generator;
 fn producer() {
   let stack = OsStack::new(0).unwrap();
   let mut gen = Generator::new(stack, move |yielder, ()| {
-    for i in 0.. { yielder.generate(i) }
+    for i in 0.. { yielder.suspend(i) }
   });
   assert_eq!(gen.next(), Some(0));
   assert_eq!(gen.next(), Some(1));

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -6,12 +6,18 @@
 // copied, modified, or distributed except according to those terms.
 extern crate fringe;
 
-use fringe::{Stack, SliceStack, OsStack};
+use fringe::{Stack, SliceStack, OwnedStack, OsStack};
 
 #[test]
 fn slice_stack() {
     let mut memory = [0; 1024];
     let stack = SliceStack(&mut memory);
+    assert_eq!(stack.base() as isize - stack.limit() as isize, 1024);
+}
+
+#[test]
+fn owned_stack() {
+    let stack = OwnedStack::new(1024);
     assert_eq!(stack.base() as isize - stack.limit() as isize, 1024);
 }
 


### PR DESCRIPTION
 * Fix illegal use of constraints in inline assembly that could result in codegen crash and inefficient code.
 * Implement OwnedStack (a stack that wraps `Box<[u8]>`).
 * Rename `Yielder::generate` to `Yielder::suspend`.