### PR TITLE
arch: bring back clobbers for input operands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ there should be at least 8 KiB of free stack space, or panicking will result in 
 
 ## Limitations
 
-The only architectures currently supported are x86 and x86_64.
+The architectures currently supported are: x86, x86_64, or1k.
 Windows is not supported (see [explanation](#windows-compatibility) below).
 
 ## Installation

--- a/src/arch/or1k.rs
+++ b/src/arch/or1k.rs
@@ -59,7 +59,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize) -> !) -> StackP
         # Set up the first part of our DWARF CFI linking stacks together.
         # When unwinding the frame corresponding to this function, a DWARF unwinder
         # will use r13 as the next call frame address, restore return address (r9)
-        # from CFA-4 and restore stack pointer (r2) from CFA-8.
+        # from CFA-4 and restore frame pointer (r2) from CFA-8.
         # This mirrors what the second half of `swap_trampoline` does.
         .cfi_def_cfa r13, 0
         .cfi_offset r2, -8

--- a/src/arch/or1k.rs
+++ b/src/arch/or1k.rs
@@ -156,7 +156,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer,
       "{r4}" (old_sp)
       "{r5}" (new_sp)
       "{r6}" (new_cfa)
-    :/*"r0", "r1",  "r2",  "r3",  "r4",  "r5",  "r6",*/"r7",
+    :/*"r0", "r1",  "r2",  "r3",*/"r4",  "r5",  "r6",  "r7",
       "r8",  "r9",  "r10", "r11", "r12", "r13", "r14", "r15",
       "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23",
       "r24", "r25", "r26", "r27", "r28", "r29", "r30", "r31",

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -151,7 +151,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer,
       "{esi}" (old_sp)
       "{edx}" (new_sp)
       "{edi}" (new_cfa)
-    :/*"eax",*/"ebx",  "ecx",/*"edx",  "esi",  "edi", "ebp",  "esp",*/
+    :/*"eax",*/"ebx", "ecx",  "edx",  "esi",  "edi",/*"ebp",  "esp",*/
       "mmx0", "mmx1", "mmx2", "mmx3", "mmx4", "mmx5", "mmx6", "mmx7",
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
       "cc", "fpsr", "flags", "memory"

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -153,7 +153,7 @@ pub unsafe fn swap(arg: usize, old_sp: &mut StackPointer, new_sp: &StackPointer,
       "{rsi}" (old_sp)
       "{rdx}" (new_sp)
       "{rcx}" (new_cfa)
-    : "rax",   "rbx", /*"rcx",   "rdx",   "rsi",   "rdi",   "rbp",   "rsp",*/
+    : "rax",   "rbx",   "rcx",   "rdx",   "rsi", /*"rdi",   "rbp",   "rsp",*/
       "r8",    "r9",    "r10",   "r11",   "r12",   "r13",   "r14",   "r15",
       "xmm0",  "xmm1",  "xmm2",  "xmm3",  "xmm4",  "xmm5",  "xmm6",  "xmm7",
       "xmm8",  "xmm9",  "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",


### PR DESCRIPTION
See commit for explanation of why this is needed.