### PR TITLE
arch/x86_64: hack to work around ld64 shortcomings on OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
 rust: nightly
+os:
+  - linux
+  - osx
 sudo: false
 install:
   - .travis/docs/install

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#![feature(asm, naked_functions)]
+#![feature(asm, naked_functions, cfg_target_vendor)]
 #![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(test, feature(test, thread_local, const_fn))]
 #![no_std]

--- a/src/os/sys.rs
+++ b/src/os/sys.rs
@@ -17,13 +17,13 @@ use self::libc::MAP_FAILED;
 const GUARD_PROT:  c_int = libc::PROT_NONE;
 const STACK_PROT:  c_int = libc::PROT_READ
                          | libc::PROT_WRITE;
-#[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+#[cfg(not(any(target_os = "freebsd", target_os = "dragonfly", target_vendor = "apple")))]
 const STACK_FLAGS: c_int = libc::MAP_STACK
                          | libc::MAP_PRIVATE
                          | libc::MAP_ANON;
 // workaround for http://lists.freebsd.org/pipermail/freebsd-bugs/2011-July/044840.html
 // according to libgreen, DragonFlyBSD suffers from this too
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_vendor = "apple"))]
 const STACK_FLAGS: c_int = libc::MAP_PRIVATE
                          | libc::MAP_ANON;
 


### PR DESCRIPTION
Fixes #35.