### PR TITLE
Ensure that the closure outlives the generator [breaking-change]

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -80,7 +80,7 @@ pub enum State {
 /// println!("{:?}", nat.next()); // prints Some(2)
 /// ```
 #[derive(Debug)]
-pub struct Generator<'a, Input: Send, Output: Send, Stack: stack::Stack> {
+pub struct Generator<'a, Input: Send + 'a, Output: Send + 'a, Stack: stack::Stack> {
   state:     State,
   stack:     Stack,
   stack_id:  debug::StackId,
@@ -89,7 +89,7 @@ pub struct Generator<'a, Input: Send, Output: Send, Stack: stack::Stack> {
 }
 
 impl<'a, Input, Output, Stack> Generator<'a, Input, Output, Stack>
-    where Input: Send, Output: Send, Stack: stack::Stack {
+    where Input: Send + 'a, Output: Send + 'a, Stack: stack::Stack {
   /// Creates a new generator.
   ///
   /// See also the [contract](../trait.GuardedStack.html) that needs to be fulfilled by `stack`.
@@ -219,7 +219,7 @@ impl<Input, Output> Yielder<Input, Output>
 }
 
 impl<'a, Output, Stack> Iterator for Generator<'a, (), Output, Stack>
-    where Output: Send, Stack: stack::Stack {
+    where Output: Send + 'a, Stack: stack::Stack {
   type Item = Output;
 
   fn next(&mut self) -> Option<Self::Item> { self.resume(()) }

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -17,7 +17,7 @@ fn add_one_fn(yielder: &mut Yielder<i32, i32>, mut input: i32) {
   }
 }
 
-fn new_add_one() -> Generator<i32, i32, OsStack> {
+fn new_add_one() -> Generator<'static, i32, i32, OsStack> {
   let stack = OsStack::new(0).unwrap();
   Generator::new(stack, add_one_fn)
 }
@@ -48,7 +48,7 @@ fn move_after_new() {
 #[should_panic]
 fn panic_safety() {
   struct Wrapper {
-    gen: Generator<(), (), OsStack>
+    gen: Generator<'static, (), (), OsStack>
   }
 
   impl Drop for Wrapper {


### PR DESCRIPTION
Previously, it was possible to cause unsafety by having the closure
refer to values with lifetimes that weren't enclosed by the generator's
lifetime.