### PR TITLE
Unwinding support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2.14"
 optional = true
 version = "1.0.0"
 
-[dev-dependencies]
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dev-dependencies]
 simd = "0.1"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ there should be at least 8 KiB of free stack space, or panicking will result in 
 
 ## Limitations
 
-The architectures currently supported are: x86, x86_64, aarch64, or1k.
+The architectures currently supported are: x86, x86_64, aarch64, arm, or1k.
 
 The platforms currently supported are: bare metal, Linux (any libc),
 FreeBSD, DragonFly BSD, macOS.
@@ -176,13 +176,15 @@ of callee-saved registers.
 
 ### Call stack splicing
 
-Non-Windows platforms use [DWARF][] for both stack unwinding and debugging. DWARF call frame
-information is very generic to be ABI-agnostic—it defines a bytecode that describes the actions
-that need to be performed to simulate returning from a function. libfringe uses this bytecode
-to specify that, after the generator function has returned, execution continues at the point
-where the generator function was resumed the last time.
+Non-Windows platforms use [DWARF][] (or the highly similar [ARM EHABI][ehabi]) for both stack
+unwinding and debugging. DWARF call frame information is very generic to be ABI-agnostic—
+it defines a bytecode that describes the actions that need to be performed to simulate
+returning from a function. libfringe uses this bytecode to specify that, after the generator
+function has returned, execution continues at the point where the generator function was
+resumed the last time.
 
 [dwarf]: http://dwarfstd.org
+[ehabi]: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0038b/IHI0038B_ehabi.pdf
 
 ## Windows compatibility
 

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -1,0 +1,292 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) Nathan Zadoks <nathan@nathan7.eu>,
+//               whitequark <whitequark@whitequark.org>
+//               Amanieu d'Antras <amanieu@gmail.com>
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// To understand the machine code in this file, keep in mind these facts:
+// * ARM AAPCS ABI passes the first argument in r0. We also use r0 to pass a value
+//   while swapping context; this is an arbitrary choice
+//   (we clobber all registers and could use any of them) but this allows us
+//   to reuse the swap function to perform the initial call.
+//
+// To understand the ARM EHABI CFI code in this file, keep in mind these facts:
+// * CFI is "call frame information"; a set of instructions to a debugger or
+//   an unwinder that allow it to simulate returning from functions. This implies
+//   restoring every register to its pre-call state, as well as the stack pointer.
+// * CFA is "call frame address"; the value of stack pointer right before the call
+//   instruction in the caller. Everything strictly below CFA (and inclusive until
+//   the next CFA) is the call frame of the callee. This implies that the return
+//   address is the part of callee's call frame.
+// * Logically, ARM EHABI CFI is a table where rows are instruction pointer values and
+//   columns describe where registers are spilled (mostly using expressions that
+//   compute a memory location as CFA+n). A .save pseudoinstruction changes
+//   the state of a column for all IP numerically larger than the one it's placed
+//   after. A .pad or .setfp pseudoinstructions change the CFA value similarly.
+// * Simulating return is as easy as restoring register values from the CFI table
+//   and then setting stack pointer to CFA.
+//
+// A high-level overview of the function of the trampolines is:
+// * The 2nd init trampoline puts a controlled value (written in swap to `new_cfa`)
+//   into r11. This is then used as the CFA for the 1st trampoline.
+// * This controlled value points to the bottom of the stack of the parent context,
+//   which holds the saved r11 and lr from the call to swap().
+// * The 1st init trampoline tells the unwinder to restore r11 and lr
+//   from the stack frame at r11 (in the parent stack), thus continuing
+//   unwinding at the swap call site instead of falling off the end of context stack.
+use core::mem;
+use arch::StackPointer;
+use unwind;
+
+pub const STACK_ALIGNMENT: usize = 8;
+
+pub unsafe fn init(stack_base: *mut u8, f: unsafe fn(usize, StackPointer)) -> StackPointer {
+  #[cfg(not(target_vendor = "apple"))]
+  #[naked]
+  unsafe extern "C" fn trampoline_1() {
+    asm!(
+      r#"
+        # gdb has a hardcoded check that rejects backtraces where frame addresses
+        # do not monotonically decrease. It is turned off if the function is called
+        # "__morestack" and that is hardcoded. So, to make gdb backtraces match
+        # the actual unwinder behavior, we call ourselves "__morestack" and mark
+        # the symbol as local; it shouldn't interfere with anything.
+      __morestack:
+      .local __morestack
+
+        # Set up the first part of our ARM EHABI CFI linking stacks together. When
+        # we reach this function from unwinding, r11 will be pointing at the bottom
+        # of the parent linked stack. This link is set each time swap() is called.
+        # When unwinding the frame corresponding to this function, a ARM EHABI unwinder
+        # will use r11+16 as the next call frame address, restore return address (lr)
+        # from CFA-8 and restore r11 from CFA-16. This mirrors what the second half
+        # of `swap_trampoline` does.
+      # .setfp  fp, sp
+      # .save   {fp, lr}
+
+        # This nop is here so that the initial swap doesn't return to the start
+        # of the trampoline, which confuses the unwinder since it will look for
+        # frame information in the previous symbol rather than this one. It is
+        # never actually executed.
+        nop
+
+      .Lend:
+      .size __morestack, .Lend-__morestack
+      "#
+      : : : : "volatile")
+  }
+
+  #[cfg(target_vendor = "apple")]
+  #[naked]
+  unsafe extern "C" fn trampoline_1() {
+    asm!(
+      r#"
+      # Identical to the above, except avoids .local/.size that aren't available on Mach-O.
+      __morestack:
+      .private_extern __morestack
+      # .setfp  fp, sp
+      # .save   {fp, lr}
+        nop
+      "#
+      : : : : "volatile")
+  }
+
+  #[naked]
+  unsafe extern "C" fn trampoline_2() {
+    asm!(
+      r#"
+        # Set up the second part of our ARM EHABI CFI.
+        # When unwinding the frame corresponding to this function, a DWARF unwinder
+        # will restore r11 (and thus CFA of the first trampoline) from the stack slot.
+        # This stack slot is updated every time swap() is called to point to the bottom
+        # of the stack of the context switch just switched from.
+      # .setfp  fp, sp
+      # .save   {fp, lr}
+
+        # This nop is here so that the return address of the swap trampoline
+        # doesn't point to the start of the symbol. This confuses gdb's backtraces,
+        # causing them to think the parent function is trampoline_1 instead of
+        # trampoline_2.
+        nop
+
+        # Call unwind_wrapper with the provided function and the stack base address.
+        add     r2, sp, #16
+        ldr     r3, [sp, #8]
+        bl      ${0}
+
+        # Restore the stack pointer of the parent context. No CFI adjustments
+        # are needed since we have the same stack frame as trampoline_1.
+        ldr     sp, [sp]
+
+        # Load frame and instruction pointers of the parent context.
+        pop     {fp, lr}
+
+        # If the returned value is nonzero, trigger an unwind in the parent
+        # context with the given exception object.
+        cmp     r0, #0
+        bne     ${1}
+
+        # Clear the stack pointer. We can't call into this context any more once
+        # the function has returned.
+        mov     r1, #0
+
+        # Return into the new context. Use `r12` instead of `lr` to avoid
+        # return address mispredictions.
+        mov     r12, lr
+        bx      r12
+      "#
+      :
+      : "s" (unwind::unwind_wrapper as usize)
+        "s" (unwind::start_unwind as usize)
+      : : "volatile")
+  }
+
+  // We set up the stack in a somewhat special way so that to the unwinder it
+  // looks like trampoline_1 has called trampoline_2, which has in turn called
+  // swap::trampoline.
+  //
+  // There are 2 call frames in this setup, each containing the return address
+  // followed by the r11 value for that frame. This setup supports unwinding
+  // using DWARF CFI as well as the frame pointer-based unwinding used by tools
+  // such as perf or dtrace.
+  let mut sp = StackPointer::new(stack_base);
+
+  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
+  sp.push(f as usize); // Function that trampoline_2 should call
+
+  // Call frame for trampoline_2. The CFA slot is updated by swap::trampoline
+  // each time a context switch is performed.
+  sp.push(trampoline_1 as usize + 4); // Return after the nop
+  sp.push(0xdead0cfa);                // CFA slot
+
+  // Call frame for swap::trampoline. We set up the r11 value to point to the
+  // parent call frame.
+  let frame = sp.offset(0);
+  sp.push(trampoline_2 as usize + 4); // Entry point, skip initial nop
+  sp.push(frame as usize);            // Pointer to parent call frame
+
+  sp
+}
+
+#[inline(always)]
+pub unsafe fn swap_link(arg: usize, new_sp: StackPointer,
+                        new_stack_base: *mut u8) -> (usize, Option<StackPointer>) {
+  let ret: usize;
+  let ret_sp: usize;
+  asm!(
+    r#"
+        # Set up the link register
+        adr     lr, 0f
+
+        # Save the frame pointer and link register; the unwinder uses them to find
+        # the CFA of the caller, and so they have to have the correct value immediately
+        # after the call instruction that invoked the trampoline.
+        push    {fp, lr}
+
+        # Pass the stack pointer of the old context to the new one.
+        mov     r1, sp
+
+        # Link the call stacks together by writing the current stack bottom
+        # address to the CFA slot in the new stack.
+        str     sp, [r3, #-16]
+
+        # Load stack pointer of the new context.
+        mov     sp, r2
+
+        # Load frame and instruction pointers of the new context.
+        pop     {fp, r12}
+
+        # Return into the new context. Use `r12` instead of `lr` to avoid
+        # return address mispredictions.
+        bx      r12
+
+      0:
+    "#
+    : "={r0}" (ret)
+      "={r1}" (ret_sp)
+    : "{r0}" (arg)
+      "{r2}" (new_sp.0)
+      "{r3}" (new_stack_base)
+    :/*r0,    r1,*/ "r2",  "r3",  "r4",  "r5",  "r6",  "r7",
+      "r8",  "r9",  "r10",/*r11,*/"r12",/*sp,*/ "lr", /*pc,*/
+      "d0",  "d1",  "d2",  "d3",  "d4",  "d5",  "d6",  "d7",
+      "d8",  "d9",  "d10", "d11", "d12", "d13", "d14", "d15",
+      "d16", "d17", "d18", "d19", "d20", "d21", "d22", "d23",
+      "d24", "d25", "d26", "d27", "d28", "d29", "d30", "d31",
+      "cc", "memory"
+    : "volatile");
+  (ret, mem::transmute(ret_sp))
+}
+
+#[inline(always)]
+pub unsafe fn swap(arg: usize, new_sp: StackPointer) -> (usize, StackPointer) {
+  // This is identical to swap_link, but without the write to the CFA slot.
+  let ret: usize;
+  let ret_sp: usize;
+  asm!(
+    r#"
+        adr     lr, 0f
+        push    {fp, lr}
+        mov     r1, sp
+        mov     sp, r2
+        pop     {fp, r12}
+        bx      r12
+      0:
+    "#
+    : "={r0}" (ret)
+      "={r1}" (ret_sp)
+    : "{r0}" (arg)
+      "{r2}" (new_sp.0)
+    :/*r0,    r1,*/ "r2",  "r3",  "r4",  "r5",  "r6",  "r7",
+      "r8",  "r9",  "r10",/*r11,*/"r12",/*sp,*/ "lr", /*pc,*/
+      "d0",  "d1",  "d2",  "d3",  "d4",  "d5",  "d6",  "d7",
+      "d8",  "d9",  "d10", "d11", "d12", "d13", "d14", "d15",
+      "d16", "d17", "d18", "d19", "d20", "d21", "d22", "d23",
+      "d24", "d25", "d26", "d27", "d28", "d29", "d30", "d31",
+      "cc", "memory"
+      // We need the "alignstack" attribute here to ensure that the stack is
+      // properly aligned if a call to start_unwind needs to be injected into
+      // our stack context.
+    : "volatile", "alignstack");
+  (ret, mem::transmute(ret_sp))
+}
+
+#[inline(always)]
+pub unsafe fn unwind(new_sp: StackPointer, new_stack_base: *mut u8) {
+  // Argument to pass to start_unwind, based on the stack base address.
+  let arg = unwind::unwind_arg(new_stack_base);
+
+  // This is identical to swap_link, except that it performs a tail call to
+  // start_unwind instead of returning into the target context.
+  asm!(
+    r#"
+        adr     lr, 0f
+        push    {fp, lr}
+        str     sp, [r3, #-16]
+        mov     sp, r2
+        pop     {fp, r12}
+
+        # Jump to the start_unwind function, which will force a stack unwind in
+        # the target context. This will eventually return to us through the
+        # stack link.
+        b       ${0}
+
+      0:
+    "#
+    :
+    : "s" (unwind::start_unwind as usize)
+      "{r0}" (arg)
+      "{r2}" (new_sp.0)
+      "{r3}" (new_stack_base)
+    : "r0",  "r1",  "r2",  "r3",  "r4",  "r5",  "r6",  "r7",
+      "r8",  "r9",  "r10",/*r11,*/"r12",/*sp,*/ "lr", /*pc,*/
+      "d0",  "d1",  "d2",  "d3",  "d4",  "d5",  "d6",  "d7",
+      "d8",  "d9",  "d10", "d11", "d12", "d13", "d14", "d15",
+      "d16", "d17", "d18", "d19", "d20", "d21", "d22", "d23",
+      "d24", "d25", "d26", "d27", "d28", "d29", "d30", "d31",
+      "cc", "memory"
+    : "volatile");
+}

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -13,6 +13,7 @@ use core::nonzero::NonZero;
 #[cfg_attr(target_arch = "x86",     path = "x86.rs")]
 #[cfg_attr(target_arch = "x86_64",  path = "x86_64.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
+#[cfg_attr(target_arch = "arm",     path = "arm.rs")]
 #[cfg_attr(target_arch = "or1k",    path = "or1k.rs")]
 mod imp;
 
@@ -40,6 +41,7 @@ impl StackPointer {
 #[cfg(test)]
 mod tests {
   extern crate test;
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
   extern crate simd;
 
   use arch::{self, StackPointer};
@@ -66,6 +68,7 @@ mod tests {
     }
   }
 
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
   #[test]
   fn context_simd() {
     unsafe fn permuter(arg: usize, stack_ptr: StackPointer) {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -47,7 +47,7 @@ mod tests {
 
   #[test]
   fn context() {
-    unsafe extern "C" fn adder(arg: usize, stack_ptr: StackPointer) {
+    unsafe fn adder(arg: usize, stack_ptr: StackPointer) {
       println!("it's alive! arg: {}", arg);
       let (arg, stack_ptr) = arch::swap(arg + 1, stack_ptr);
       println!("still alive! arg: {}", arg);
@@ -68,7 +68,7 @@ mod tests {
 
   #[test]
   fn context_simd() {
-    unsafe extern "C" fn permuter(arg: usize, stack_ptr: StackPointer) {
+    unsafe fn permuter(arg: usize, stack_ptr: StackPointer) {
       // This will crash if the stack is not aligned properly.
       let x = simd::i32x4::splat(arg as i32);
       let y = x * x;
@@ -91,7 +91,7 @@ mod tests {
     }
   }
 
-  unsafe extern "C" fn do_panic(arg: usize, stack_ptr: StackPointer) {
+  unsafe fn do_panic(arg: usize, stack_ptr: StackPointer) {
     match arg {
       0 => panic!("arg=0"),
       1 => {
@@ -127,7 +127,7 @@ mod tests {
 
   #[test]
   fn ret() {
-    unsafe extern "C" fn ret2(_: usize, _: StackPointer) {}
+    unsafe fn ret2(_: usize, _: StackPointer) {}
 
     unsafe {
       let stack = OsStack::new(4 << 20).unwrap();
@@ -140,7 +140,7 @@ mod tests {
 
   #[bench]
   fn swap(b: &mut test::Bencher) {
-    unsafe extern "C" fn loopback(mut arg: usize, mut stack_ptr: StackPointer) {
+    unsafe fn loopback(mut arg: usize, mut stack_ptr: StackPointer) {
       // This deliberately does not ignore arg, to measure the time it takes
       // to move the return value between registers.
       loop {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -7,6 +7,7 @@
 // copied, modified, or distributed except according to those terms.
 
 pub use self::imp::*;
+use core::nonzero::NonZero;
 
 #[allow(unused_attributes)] // rust-lang/rust#35584
 #[cfg_attr(target_arch = "x86",     path = "x86.rs")]
@@ -15,65 +16,86 @@ pub use self::imp::*;
 #[cfg_attr(target_arch = "or1k",    path = "or1k.rs")]
 mod imp;
 
+#[derive(Debug, Clone, Copy)]
+pub struct StackPointer(NonZero<*mut usize>);
+
+impl StackPointer {
+  #[inline(always)]
+  pub unsafe fn push(&mut self, val: usize) {
+    self.0 = NonZero::new(self.0.offset(-1));
+    **self.0 = val;
+  }
+
+  #[inline(always)]
+  pub unsafe fn new(sp: *mut u8) -> StackPointer {
+    StackPointer(NonZero::new(sp as *mut usize))
+  }
+
+  #[inline(always)]
+  pub unsafe fn offset(&self, count: isize) -> *mut usize {
+    self.0.offset(count)
+  }
+}
+
 #[cfg(test)]
 mod tests {
   extern crate test;
   extern crate simd;
 
   use arch::{self, StackPointer};
-  use ::OsStack;
+  use ::{Stack, OsStack};
 
   #[test]
   fn context() {
-    unsafe extern "C" fn adder(arg: usize, stack_ptr: StackPointer) -> ! {
+    unsafe extern "C" fn adder(arg: usize, stack_ptr: StackPointer) {
       println!("it's alive! arg: {}", arg);
-      let (arg, stack_ptr) = arch::swap(arg + 1, stack_ptr, None);
+      let (arg, stack_ptr) = arch::swap(arg + 1, stack_ptr);
       println!("still alive! arg: {}", arg);
-      arch::swap(arg + 1, stack_ptr, None);
+      arch::swap(arg + 1, stack_ptr);
       panic!("i should be dead");
     }
 
     unsafe {
       let stack = OsStack::new(4 << 20).unwrap();
-      let stack_ptr = arch::init(&stack, adder);
+      let stack_ptr = arch::init(stack.base(), adder);
 
-      let (ret, stack_ptr) = arch::swap(10, stack_ptr, Some(&stack));
+      let (ret, stack_ptr) = arch::swap_link(10, stack_ptr, stack.base());
       assert_eq!(ret, 11);
-      let (ret, _) = arch::swap(50, stack_ptr, Some(&stack));
+      let (ret, _) = arch::swap_link(50, stack_ptr.unwrap(), stack.base());
       assert_eq!(ret, 51);
     }
   }
 
   #[test]
   fn context_simd() {
-    unsafe extern "C" fn permuter(arg: usize, stack_ptr: StackPointer) -> ! {
+    unsafe extern "C" fn permuter(arg: usize, stack_ptr: StackPointer) {
       // This will crash if the stack is not aligned properly.
       let x = simd::i32x4::splat(arg as i32);
       let y = x * x;
       println!("simd result: {:?}", y);
-      let (_, stack_ptr) = arch::swap(0, stack_ptr, None);
+      let (_, stack_ptr) = arch::swap(0, stack_ptr);
       // And try again after a context switch.
       let x = simd::i32x4::splat(arg as i32);
       let y = x * x;
       println!("simd result: {:?}", y);
-      arch::swap(0, stack_ptr, None);
+      arch::swap(0, stack_ptr);
       panic!("i should be dead");
     }
 
     unsafe {
       let stack = OsStack::new(4 << 20).unwrap();
-      let stack_ptr = arch::init(&stack, permuter);
+      let stack_ptr = arch::init(stack.base(), permuter);
 
-      let (_, stack_ptr) = arch::swap(10, stack_ptr, Some(&stack));
-      arch::swap(20, stack_ptr, Some(&stack));
+      let (_, stack_ptr) = arch::swap_link(10, stack_ptr, stack.base());
+      arch::swap_link(20, stack_ptr.unwrap(), stack.base());
     }
   }
 
-  unsafe extern "C" fn do_panic(arg: usize, stack_ptr: StackPointer) -> ! {
+  unsafe extern "C" fn do_panic(arg: usize, stack_ptr: StackPointer) {
     match arg {
       0 => panic!("arg=0"),
       1 => {
-        arch::swap(0, stack_ptr, None);
+        arch::swap(0, stack_ptr);
         panic!("arg=1");
       }
       _ => unreachable!()
@@ -85,9 +107,9 @@ mod tests {
   fn panic_after_start() {
     unsafe {
       let stack = OsStack::new(4 << 20).unwrap();
-      let stack_ptr = arch::init(&stack, do_panic);
+      let stack_ptr = arch::init(stack.base(), do_panic);
 
-      arch::swap(0, stack_ptr, Some(&stack));
+      arch::swap_link(0, stack_ptr, stack.base());
     }
   }
 
@@ -96,20 +118,33 @@ mod tests {
   fn panic_after_swap() {
     unsafe {
       let stack = OsStack::new(4 << 20).unwrap();
-      let stack_ptr = arch::init(&stack, do_panic);
+      let stack_ptr = arch::init(stack.base(), do_panic);
 
-      let (_, stack_ptr) = arch::swap(1, stack_ptr, Some(&stack));
-      arch::swap(0, stack_ptr, Some(&stack));
+      let (_, stack_ptr) = arch::swap_link(1, stack_ptr, stack.base());
+      arch::swap_link(0, stack_ptr.unwrap(), stack.base());
+    }
+  }
+
+  #[test]
+  fn ret() {
+    unsafe extern "C" fn ret2(_: usize, _: StackPointer) {}
+
+    unsafe {
+      let stack = OsStack::new(4 << 20).unwrap();
+      let stack_ptr = arch::init(stack.base(), ret2);
+
+      let (_, stack_ptr) = arch::swap_link(0, stack_ptr, stack.base());
+      assert!(stack_ptr.is_none());
     }
   }
 
   #[bench]
   fn swap(b: &mut test::Bencher) {
-    unsafe extern "C" fn loopback(mut arg: usize, mut stack_ptr: StackPointer) -> ! {
+    unsafe extern "C" fn loopback(mut arg: usize, mut stack_ptr: StackPointer) {
       // This deliberately does not ignore arg, to measure the time it takes
       // to move the return value between registers.
       loop {
-        let data = arch::swap(arg, stack_ptr, None);
+        let data = arch::swap(arg, stack_ptr);
         arg = data.0;
         stack_ptr = data.1;
       }
@@ -117,10 +152,10 @@ mod tests {
 
     unsafe {
       let stack = OsStack::new(4 << 20).unwrap();
-      let mut stack_ptr = arch::init(&stack, loopback);
+      let mut stack_ptr = arch::init(stack.base(), loopback);
 
       b.iter(|| for _ in 0..10 {
-        stack_ptr = arch::swap(0, stack_ptr, Some(&stack)).1;
+        stack_ptr = arch::swap_link(0, stack_ptr, stack.base()).1.unwrap();
       });
     }
   }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -42,14 +42,11 @@
 //   address from the stack frame at %ebp (in the parent stack), thus continuing
 //   unwinding at the swap call site instead of falling off the end of context stack.
 use core::mem;
-use stack::Stack;
+use arch::StackPointer;
 
 pub const STACK_ALIGNMENT: usize = 16;
 
-#[derive(Debug, Clone, Copy)]
-pub struct StackPointer(*mut usize);
-
-pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -> !) -> StackPointer {
+pub unsafe fn init(stack_base: *mut u8, f: unsafe extern "C" fn(usize, StackPointer)) -> StackPointer {
   #[cfg(not(target_vendor = "apple"))]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
@@ -128,14 +125,29 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
         pushl   %esi
         pushl   %edi
         # Call the provided function.
-        calll  *16(%esp)
+        calll   *16(%esp)
+
+        # Clear the stack pointer. We can't call into this context any more once
+        # the function has returned.
+        xorl    %esi, %esi
+
+        # Restore the stack pointer of the parent context. No CFI adjustments
+        # are needed since we have the same stack frame as trampoline_1.
+        movl    8(%esp), %esp
+
+        # Restore frame pointer of the parent context.
+        popl    %ebp
+        .cfi_adjust_cfa_offset -4
+        .cfi_restore %ebp
+
+        # Return into the parent context. Use `pop` and `jmp` instead of a `ret`
+        # to avoid return address mispredictions (~8ns per `ret` on Ivy Bridge).
+        popl    %eax
+        .cfi_adjust_cfa_offset -4
+        .cfi_register %eip, %eax
+        jmpl    *%eax
       "#
       : : : : "volatile")
-  }
-
-  unsafe fn push(sp: &mut StackPointer, val: usize) {
-    sp.0 = sp.0.offset(-1);
-    *sp.0 = val
   }
 
   // We set up the stack in a somewhat special way so that to the unwinder it
@@ -146,39 +158,30 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   // followed by the %ebp value for that frame. This setup supports unwinding
   // using DWARF CFI as well as the frame pointer-based unwinding used by tools
   // such as perf or dtrace.
-  let mut sp = StackPointer(stack.base() as *mut usize);
+  let mut sp = StackPointer::new(stack_base);
 
-  push(&mut sp, 0 as usize); // Padding to ensure the stack is properly aligned
-  push(&mut sp, 0 as usize); // Padding to ensure the stack is properly aligned
-  push(&mut sp, 0 as usize); // Padding to ensure the stack is properly aligned
-  push(&mut sp, f as usize); // Function that trampoline_2 should call
+  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
+  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
+  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
+  sp.push(f as usize); // Function that trampoline_2 should call
 
   // Call frame for trampoline_2. The CFA slot is updated by swap::trampoline
   // each time a context switch is performed.
-  push(&mut sp, trampoline_1 as usize + 2); // Return after the 2 nops
-  push(&mut sp, 0xdead0cfa);                // CFA slot
+  sp.push(trampoline_1 as usize + 2); // Return after the 2 nops
+  sp.push(0xdead0cfa);                // CFA slot
 
   // Call frame for swap::trampoline. We set up the %ebp value to point to the
   // parent call frame.
-  let frame = sp;
-  push(&mut sp, trampoline_2 as usize + 1); // Entry point, skip initial nop
-  push(&mut sp, frame.0 as usize);          // Pointer to parent call frame
+  let frame = sp.offset(0);
+  sp.push(trampoline_2 as usize + 1); // Entry point, skip initial nop
+  sp.push(frame as usize);            // Pointer to parent call frame
 
   sp
 }
 
 #[inline(always)]
-pub unsafe fn swap(arg: usize, new_sp: StackPointer,
-                   new_stack: Option<&Stack>) -> (usize, StackPointer) {
-  // Address of the topmost CFA stack slot.
-  let mut dummy: usize = mem::uninitialized();
-  let new_cfa = if let Some(new_stack) = new_stack {
-    (new_stack.base() as *mut usize).offset(-6)
-  } else {
-    // Just pass a dummy pointer if we aren't linking the stack
-    &mut dummy
-  };
-
+pub unsafe fn swap_link(arg: usize, new_sp: StackPointer,
+                        new_stack_base: *mut u8) -> (usize, Option<StackPointer>) {
   #[naked]
   unsafe extern "C" fn trampoline() {
     asm!(
@@ -192,7 +195,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
         # Link the call stacks together by writing the current stack bottom
         # address to the CFA slot in the new stack.
-        movl    %esp, (%ecx)
+        movl    %esp, -24(%ecx)
 
         # Pass the stack pointer of the old context to the new one.
         movl    %esp, %esi
@@ -215,7 +218,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
   }
 
   let ret: usize;
-  let ret_sp: *mut usize;
+  let ret_sp: usize;
   asm!(
     r#"
       # Push instruction pointer of the old context and switch to
@@ -227,11 +230,53 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
     : "s" (trampoline as usize)
       "{edi}" (arg)
       "{edx}" (new_sp.0)
-      "{ecx}" (new_cfa)
+      "{ecx}" (new_stack_base)
     : "eax", "ebx", "ecx",  "edx", /*"esi",  "edi", "ebp",  "esp",*/
       "mm0",  "mm1",  "mm2",  "mm3",  "mm4",  "mm5",  "mm6",  "mm7",
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
       "cc", "dirflag", "fpsr", "flags", "memory"
     : "volatile");
-  (ret, StackPointer(ret_sp))
+  (ret, mem::transmute(ret_sp))
+}
+
+#[inline(always)]
+pub unsafe fn swap(arg: usize, new_sp: StackPointer) -> (usize, StackPointer) {
+  // This is identical to swap_link, but without the write to the CFA slot.
+  #[naked]
+  unsafe extern "C" fn trampoline() {
+    asm!(
+      r#"
+        pushl   %ebp
+        .cfi_adjust_cfa_offset 4
+        .cfi_rel_offset %ebp, 0
+        movl    %esp, %esi
+        movl    %edx, %esp
+        popl    %ebp
+        .cfi_adjust_cfa_offset -4
+        .cfi_restore %ebp
+        popl    %eax
+        .cfi_adjust_cfa_offset -4
+        .cfi_register %eip, %eax
+        jmpl    *%eax
+      "#
+      : : : : "volatile")
+  }
+
+  let ret: usize;
+  let ret_sp: usize;
+  asm!(
+    r#"
+      call    ${2:c}
+    "#
+    : "={edi}" (ret)
+      "={esi}" (ret_sp)
+    : "s" (trampoline as usize)
+      "{edi}" (arg)
+      "{edx}" (new_sp.0)
+    : "eax", "ebx", "ecx",  "edx", /*"esi",  "edi", "ebp",  "esp",*/
+      "mm0",  "mm1",  "mm2",  "mm3",  "mm4",  "mm5",  "mm6",  "mm7",
+      "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
+      "cc", "dirflag", "fpsr", "flags", "memory"
+    : "volatile");
+  (ret, mem::transmute(ret_sp))
 }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -43,10 +43,28 @@
 //   unwinding at the swap call site instead of falling off the end of context stack.
 use core::mem;
 use arch::StackPointer;
+use unwind;
 
 pub const STACK_ALIGNMENT: usize = 16;
 
-pub unsafe fn init(stack_base: *mut u8, f: unsafe extern "C" fn(usize, StackPointer)) -> StackPointer {
+// Rust's fastcall support is currently broken due to #18086, so we use a
+// custom wrapper instead. We don't quite follow the normal fastcall ABI since
+// we accept the first parameter in %edi rather than the usual %ecx.
+#[naked]
+unsafe extern "C" fn fastcall_start_unwind() {
+  asm!(
+    r#"
+      subl    $$12, %esp
+      .cfi_adjust_cfa_offset 12
+      movl    %edi, (%esp)
+      call    ${0:c}
+    "#
+    :
+    : "s" (unwind::start_unwind as usize)
+    : : "volatile")
+}
+
+pub unsafe fn init(stack_base: *mut u8, f: unsafe fn(usize, StackPointer)) -> StackPointer {
   #[cfg(not(target_vendor = "apple"))]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
@@ -121,24 +139,32 @@ pub unsafe fn init(stack_base: *mut u8, f: unsafe extern "C" fn(usize, StackPoin
         # trampoline_2.
         nop
 
-        # Push arguments.
+        # Call unwind_wrapper with the provided function and the CFA address.
+        leal    16(%esp), %edx
+        pushl   8(%esp)
+        pushl   %edx
         pushl   %esi
         pushl   %edi
-        # Call the provided function.
-        calll   *16(%esp)
-
-        # Clear the stack pointer. We can't call into this context any more once
-        # the function has returned.
-        xorl    %esi, %esi
+        call    ${0:c}
 
         # Restore the stack pointer of the parent context. No CFI adjustments
         # are needed since we have the same stack frame as trampoline_1.
-        movl    8(%esp), %esp
+        movl    16(%esp), %esp
 
         # Restore frame pointer of the parent context.
         popl    %ebp
         .cfi_adjust_cfa_offset -4
         .cfi_restore %ebp
+
+        # If the returned value is nonzero, trigger an unwind in the parent
+        # context with the given exception object.
+        movl    %eax, %edi
+        testl   %eax, %eax
+        jnz     ${1:c}
+
+        # Clear the stack pointer. We can't call into this context any more once
+        # the function has returned.
+        xorl    %esi, %esi
 
         # Return into the parent context. Use `pop` and `jmp` instead of a `ret`
         # to avoid return address mispredictions (~8ns per `ret` on Ivy Bridge).
@@ -147,7 +173,10 @@ pub unsafe fn init(stack_base: *mut u8, f: unsafe extern "C" fn(usize, StackPoin
         .cfi_register %eip, %eax
         jmpl    *%eax
       "#
-      : : : : "volatile")
+      :
+      : "s" (unwind::unwind_wrapper as usize)
+        "s" (fastcall_start_unwind as usize)
+      : : "volatile")
   }
 
   // We set up the stack in a somewhat special way so that to the unwinder it
@@ -160,8 +189,6 @@ pub unsafe fn init(stack_base: *mut u8, f: unsafe extern "C" fn(usize, StackPoin
   // such as perf or dtrace.
   let mut sp = StackPointer::new(stack_base);
 
-  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
-  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
   sp.push(0 as usize); // Padding to ensure the stack is properly aligned
   sp.push(f as usize); // Function that trampoline_2 should call
 
@@ -195,7 +222,7 @@ pub unsafe fn swap_link(arg: usize, new_sp: StackPointer,
 
         # Link the call stacks together by writing the current stack bottom
         # address to the CFA slot in the new stack.
-        movl    %esp, -24(%ecx)
+        movl    %esp, -16(%ecx)
 
         # Pass the stack pointer of the old context to the new one.
         movl    %esp, %esi
@@ -223,7 +250,7 @@ pub unsafe fn swap_link(arg: usize, new_sp: StackPointer,
     r#"
       # Push instruction pointer of the old context and switch to
       # the new context.
-      call    ${2:c}
+      call    ${2:c}@plt
     "#
     : "={edi}" (ret)
       "={esi}" (ret_sp)
@@ -231,7 +258,7 @@ pub unsafe fn swap_link(arg: usize, new_sp: StackPointer,
       "{edi}" (arg)
       "{edx}" (new_sp.0)
       "{ecx}" (new_stack_base)
-    : "eax", "ebx", "ecx",  "edx", /*"esi",  "edi", "ebp",  "esp",*/
+    : "eax",  "ebx",  "ecx",  "edx",/*"esi",  "edi",  "ebp",  "esp",*/
       "mm0",  "mm1",  "mm2",  "mm3",  "mm4",  "mm5",  "mm6",  "mm7",
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
       "cc", "dirflag", "fpsr", "flags", "memory"
@@ -266,17 +293,66 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer) -> (usize, StackPointer) {
   let ret_sp: usize;
   asm!(
     r#"
-      call    ${2:c}
+      call    ${2:c}@plt
     "#
     : "={edi}" (ret)
       "={esi}" (ret_sp)
     : "s" (trampoline as usize)
       "{edi}" (arg)
       "{edx}" (new_sp.0)
-    : "eax", "ebx", "ecx",  "edx", /*"esi",  "edi", "ebp",  "esp",*/
+    : "eax",  "ebx",  "ecx",  "edx",/*"esi",  "edi",  "ebp",  "esp",*/
+      "mm0",  "mm1",  "mm2",  "mm3",  "mm4",  "mm5",  "mm6",  "mm7",
+      "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
+      "cc", "dirflag", "fpsr", "flags", "memory"
+      // We need the "alignstack" attribute here to ensure that the stack is
+      // properly aligned if a call to start_unwind needs to be injected into
+      // our stack context.
+    : "volatile", "alignstack");
+  (ret, mem::transmute(ret_sp))
+}
+
+#[inline(always)]
+pub unsafe fn unwind(new_sp: StackPointer, new_stack_base: *mut u8) {
+  // Argument to pass to start_unwind, based on the stack base address.
+  let arg = unwind::unwind_arg(new_stack_base);
+
+  // This is identical to swap_link, except that it performs a tail call to
+  // start_unwind instead of returning into the target context.
+  #[naked]
+  unsafe extern "C" fn trampoline() {
+    asm!(
+      r#"
+        pushl   %ebp
+        .cfi_adjust_cfa_offset 4
+        .cfi_rel_offset %ebp, 0
+        movl    %esp, -16(%ecx)
+        movl    %edx, %esp
+        popl    %ebp
+        .cfi_adjust_cfa_offset -4
+        .cfi_restore %ebp
+
+        # Jump to the start_unwind function, which will force a stack unwind in
+        # the target context. This will eventually return to us through the
+        # stack link.
+        jmp     ${0:c}
+      "#
+      :
+      : "s" (fastcall_start_unwind as usize)
+      : : "volatile")
+  }
+
+  asm!(
+    r#"
+      call    ${0:c}@plt
+    "#
+    :
+    : "s" (trampoline as usize)
+      "{edi}" (arg)
+      "{edx}" (new_sp.0)
+      "{ecx}" (new_stack_base)
+    : "eax",  "ebx",  "ecx",  "edx",  "esi",  "edi",/*"ebp",  "esp",*/
       "mm0",  "mm1",  "mm2",  "mm3",  "mm4",  "mm5",  "mm6",  "mm7",
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
       "cc", "dirflag", "fpsr", "flags", "memory"
     : "volatile");
-  (ret, mem::transmute(ret_sp))
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -47,14 +47,11 @@
 //   address from the stack frame at %rbp (in the parent stack), thus continuing
 //   unwinding at the swap call site instead of falling off the end of context stack.
 use core::mem;
-use stack::Stack;
+use arch::StackPointer;
 
 pub const STACK_ALIGNMENT: usize = 16;
 
-#[derive(Debug, Clone, Copy)]
-pub struct StackPointer(*mut usize);
-
-pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -> !) -> StackPointer {
+pub unsafe fn init(stack_base: *mut u8, f: unsafe extern "C" fn(usize, StackPointer)) -> StackPointer {
   #[cfg(not(target_vendor = "apple"))]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
@@ -130,14 +127,29 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
         nop
 
         # Call the provided function.
-        call    *16(%rsp)
+        callq   *16(%rsp)
+
+        # Clear the stack pointer. We can't call into this context any more once
+        # the function has returned.
+        xorq    %rsi, %rsi
+
+        # Restore the stack pointer of the parent context. No CFI adjustments
+        # are needed since we have the same stack frame as trampoline_1.
+        movq    (%rsp), %rsp
+
+        # Restore frame pointer of the parent context.
+        popq    %rbp
+        .cfi_adjust_cfa_offset -8
+        .cfi_restore %rbp
+
+        # Return into the parent context. Use `pop` and `jmp` instead of a `ret`
+        # to avoid return address mispredictions (~8ns per `ret` on Ivy Bridge).
+        popq    %rax
+        .cfi_adjust_cfa_offset -8
+        .cfi_register %rip, %rax
+        jmpq    *%rax
       "#
       : : : : "volatile")
-  }
-
-  unsafe fn push(sp: &mut StackPointer, val: usize) {
-    sp.0 = sp.0.offset(-1);
-    *sp.0 = val
   }
 
   // We set up the stack in a somewhat special way so that to the unwinder it
@@ -148,39 +160,30 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   // followed by the %rbp value for that frame. This setup supports unwinding
   // using DWARF CFI as well as the frame pointer-based unwinding used by tools
   // such as perf or dtrace.
-  let mut sp = StackPointer(stack.base() as *mut usize);
+  let mut sp = StackPointer::new(stack_base);
 
-  push(&mut sp, 0 as usize); // Padding to ensure the stack is properly aligned
-  push(&mut sp, f as usize); // Function that trampoline_2 should call
+  sp.push(0 as usize); // Padding to ensure the stack is properly aligned
+  sp.push(f as usize); // Function that trampoline_2 should call
 
   // Call frame for trampoline_2. The CFA slot is updated by swap::trampoline
   // each time a context switch is performed.
-  push(&mut sp, trampoline_1 as usize + 2); // Return after the 2 nops
-  push(&mut sp, 0xdeaddeaddead0cfa);        // CFA slot
+  sp.push(trampoline_1 as usize + 2); // Return after the 2 nops
+  sp.push(0xdeaddeaddead0cfa);        // CFA slot
 
   // Call frame for swap::trampoline. We set up the %rbp value to point to the
   // parent call frame.
-  let frame = sp;
-  push(&mut sp, trampoline_2 as usize + 1); // Entry point, skip initial nop
-  push(&mut sp, frame.0 as usize);          // Pointer to parent call frame
+  let frame = sp.offset(0);
+  sp.push(trampoline_2 as usize + 1); // Entry point, skip initial nop
+  sp.push(frame as usize);            // Pointer to parent call frame
 
   sp
 }
 
 #[inline(always)]
-pub unsafe fn swap(arg: usize, new_sp: StackPointer,
-                   new_stack: Option<&Stack>) -> (usize, StackPointer) {
-  // Address of the topmost CFA stack slot.
-  let mut dummy: usize = mem::uninitialized();
-  let new_cfa = if let Some(new_stack) = new_stack {
-    (new_stack.base() as *mut usize).offset(-4)
-  } else {
-    // Just pass a dummy pointer if we aren't linking the stack
-    &mut dummy
-  };
-
+pub unsafe fn swap_link(arg: usize, new_sp: StackPointer,
+                        new_stack_base: *mut u8) -> (usize, Option<StackPointer>) {
   let ret: usize;
-  let ret_sp: *mut usize;
+  let ret_sp: usize;
   asm!(
     r#"
         # Push the return address
@@ -194,7 +197,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
         # Link the call stacks together by writing the current stack bottom
         # address to the CFA slot in the new stack.
-        movq    %rsp, (%rcx)
+        movq    %rsp, -32(%rcx)
 
         # Pass the stack pointer of the old context to the new one.
         movq    %rsp, %rsi
@@ -216,7 +219,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
       "={rsi}" (ret_sp)
     : "{rdi}" (arg)
       "{rdx}" (new_sp.0)
-      "{rcx}" (new_cfa)
+      "{rcx}" (new_stack_base)
     : "rax",   "rbx",   "rcx",   "rdx", /*"rsi",   "rdi",   "rbp",   "rsp",*/
       "r8",    "r9",    "r10",   "r11",   "r12",   "r13",   "r14",   "r15",
       "mm0",   "mm1",   "mm2",   "mm3",   "mm4",   "mm5",   "mm6",   "mm7",
@@ -231,5 +234,38 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
       // the "alignstack" LLVM inline assembly option does exactly the same
       // thing on x86_64.
     : "volatile", "alignstack");
-  (ret, StackPointer(ret_sp))
+  (ret, mem::transmute(ret_sp))
+}
+
+#[inline(always)]
+pub unsafe fn swap(arg: usize, new_sp: StackPointer) -> (usize, StackPointer) {
+  // This is identical to swap_link, but without the write to the CFA slot.
+  let ret: usize;
+  let ret_sp: usize;
+  asm!(
+    r#"
+        leaq    0f(%rip), %rax
+        pushq   %rax
+        pushq   %rbp
+        movq    %rsp, %rsi
+        movq    %rdx, %rsp
+        popq    %rbp
+        popq    %rax
+        jmpq    *%rax
+      0:
+    "#
+    : "={rdi}" (ret)
+      "={rsi}" (ret_sp)
+    : "{rdi}" (arg)
+      "{rdx}" (new_sp.0)
+    : "rax",   "rbx",   "rcx",   "rdx", /*"rsi",   "rdi",   "rbp",   "rsp",*/
+      "r8",    "r9",    "r10",   "r11",   "r12",   "r13",   "r14",   "r15",
+      "mm0",   "mm1",   "mm2",   "mm3",   "mm4",   "mm5",   "mm6",   "mm7",
+      "xmm0",  "xmm1",  "xmm2",  "xmm3",  "xmm4",  "xmm5",  "xmm6",  "xmm7",
+      "xmm8",  "xmm9",  "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",
+      "xmm16", "xmm17", "xmm18", "xmm19", "xmm20", "xmm21", "xmm22", "xmm23",
+      "xmm24", "xmm25", "xmm26", "xmm27", "xmm28", "xmm29", "xmm30", "xmm31",
+      "cc", "dirflag", "fpsr", "flags", "memory"
+    : "volatile", "alignstack");
+  (ret, mem::transmute(ret_sp))
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -19,6 +19,36 @@ use stack;
 use debug;
 use arch::{self, StackPointer};
 
+// Wrapper to prevent the compiler from automatically dropping a value when it
+// goes out of scope. This is particularly useful when dealing with unwinding
+// since mem::forget won't be executed when unwinding.
+#[allow(unions_with_drop_fields)]
+union NoDrop<T> {
+  inner: T,
+}
+
+// Try to pack a value into a usize if it fits, otherwise pass its address as a usize.
+unsafe fn encode_usize<T>(val: &NoDrop<T>) -> usize {
+  if mem::size_of::<T>() <= mem::size_of::<usize>() &&
+     mem::align_of::<T>() <= mem::align_of::<usize>() {
+    let mut out = 0;
+    ptr::copy_nonoverlapping(&val.inner, &mut out as *mut usize as *mut T, 1);
+    out
+  } else {
+    &val.inner as *const T as usize
+  }
+}
+
+// Unpack a usize produced by encode_usize.
+unsafe fn decode_usize<T>(val: usize) -> T {
+  if mem::size_of::<T>() <= mem::size_of::<usize>() &&
+     mem::align_of::<T>() <= mem::align_of::<usize>() {
+    ptr::read(&val as *const usize as *const T)
+  } else {
+    ptr::read(val as *const T)
+  }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum State {
   /// Generator can be resumed. This is the initial state.
@@ -113,10 +143,10 @@ impl<'a, Input, Output, Stack> Generator<'a, Input, Output, Stack>
     unsafe extern "C" fn generator_wrapper<Input, Output, Stack, F>(env: usize, stack_ptr: StackPointer)
         where Stack: stack::Stack, F: FnOnce(&Yielder<Input, Output>, Input) {
       // Retrieve our environment from the callee and return control to it.
-      let f = ptr::read(env as *const F);
+      let f: F = decode_usize(env);
       let (data, stack_ptr) = arch::swap(0, stack_ptr);
       // See the second half of Yielder::suspend_bare.
-      let input = ptr::read(data as *const Input);
+      let input = decode_usize(data);
       // Run the body of the generator.
       let yielder = Yielder::new(stack_ptr);
       f(&yielder, input);
@@ -126,8 +156,8 @@ impl<'a, Input, Output, Stack> Generator<'a, Input, Output, Stack>
     let stack_ptr = arch::init(stack.base(), generator_wrapper::<Input, Output, Stack, F>);
 
     // Transfer environment to the callee.
-    let stack_ptr = arch::swap_link(&f as *const F as usize, stack_ptr, stack.base()).1;
-    mem::forget(f);
+    let f2 = NoDrop { inner: f };
+    let stack_ptr = arch::swap_link(encode_usize(&f2), stack_ptr, stack.base()).1;
 
     Generator {
       stack:     stack,
@@ -150,13 +180,13 @@ impl<'a, Input, Output, Stack> Generator<'a, Input, Output, Stack>
 
       // Switch to the generator function, and retrieve the yielded value.
       unsafe {
-        let (data_out, stack_ptr) = arch::swap_link(&input as *const Input as usize, stack_ptr, self.stack.base());
+        let input2 = NoDrop { inner: input };
+        let (data_out, stack_ptr) = arch::swap_link(encode_usize(&input2), stack_ptr, self.stack.base());
         self.stack_ptr = stack_ptr;
-        mem::forget(input);
 
         // If the generator function has finished, return None, otherwise return the
         // yielded value.
-        stack_ptr.map(|_| ptr::read(data_out as *const Output))
+        stack_ptr.map(|_| decode_usize(data_out))
       }
     })
   }
@@ -199,10 +229,10 @@ impl<Input, Output> Yielder<Input, Output> {
   #[inline(always)]
   pub fn suspend(&self, item: Output) -> Input {
     unsafe {
-      let (data, stack_ptr) = arch::swap(&item as *const Output as usize, self.stack_ptr.get());
-      mem::forget(item);
+      let item2 = NoDrop { inner: item };
+      let (data, stack_ptr) = arch::swap(encode_usize(&item2), self.stack_ptr.get());
       self.stack_ptr.set(stack_ptr);
-      ptr::read(data as *const Input)
+      decode_usize(data)
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#![feature(asm, naked_functions, cfg_target_vendor, nonzero)]
+#![feature(asm, naked_functions, cfg_target_vendor, nonzero, untagged_unions)]
 #![cfg_attr(feature = "alloc", feature(alloc, heap_api))]
 #![cfg_attr(test, feature(test))]
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub const STACK_ALIGNMENT: usize = arch::STACK_ALIGNMENT;
 
 mod debug;
 
+mod unwind;
+
 pub mod generator;
 
 mod stack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#![feature(asm, naked_functions, cfg_target_vendor)]
+#![feature(asm, naked_functions, cfg_target_vendor, nonzero)]
 #![cfg_attr(feature = "alloc", feature(alloc, heap_api))]
 #![cfg_attr(test, feature(test))]
 #![no_std]

--- a/src/stack/os/mod.rs
+++ b/src/stack/os/mod.rs
@@ -29,8 +29,8 @@ impl OsStack {
   pub fn new(size: usize) -> Result<OsStack, IoError> {
     let page_size = sys::page_size();
 
-    // Stacks have to be at least one page long.
-    let len = if size == 0 { page_size } else { size };
+    // Stacks have to be at least 16KB to support unwinding.
+    let len = if size == 0 { 16384 } else { size };
 
     // Round the length one page size up, using the fact that the page size
     // is a power of two.

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -28,7 +28,9 @@ fn have_cross_stack_unwind() -> bool {
   //   for now.
   // - iOS on ARM uses setjmp/longjmp instead of DWARF-2 unwinding, which needs
   //   to be explicitly saved/restored when switching contexts.
-  !(cfg!(windows) || cfg!(all(target_os = "ios", target_arch = "arm")))
+  // - LLVM doesn't currently support ARM EHABI directives in inline assembly so
+  //   we instead need to propagate exceptions manually across contexts.
+  !(cfg!(windows) || cfg!(target_arch = "arm"))
 }
 
 // Wrapper around the root function of a generator which handles unwinding.

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -1,0 +1,77 @@
+// This file is part of libfringe, a low-level green threading library.
+// Copyright (c) Amanieu d'Antras <amanieu@gmail.com>,
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+extern crate std;
+
+use self::std::panic;
+use self::std::boxed::Box;
+use core::any::Any;
+use arch::StackPointer;
+
+// Marker object that is passed through the stack unwinding
+struct UnwindMarker {
+  // We use the stack base as an identifier so that nested generators are handled
+  // correctly. When unwinding, we will want to continue through any number of
+  // nested generators until we reach the one with a matching identifier.
+  stack_base: *mut u8,
+}
+unsafe impl Send for UnwindMarker {}
+
+// Whether the current platform support unwinding across multiple stacks.
+#[inline]
+fn have_cross_stack_unwind() -> bool {
+  // - Windows uses SEH for unwinding instead of libunwind. While it may be
+  //   possible to munge it so support cross-stack unwinding, we stay conservative
+  //   for now.
+  // - iOS on ARM uses setjmp/longjmp instead of DWARF-2 unwinding, which needs
+  //   to be explicitly saved/restored when switching contexts.
+  !(cfg!(windows) || cfg!(all(target_os = "ios", target_arch = "arm")))
+}
+
+// Wrapper around the root function of a generator which handles unwinding.
+pub unsafe extern "C" fn unwind_wrapper(arg: usize, sp: StackPointer, stack_base: *mut u8,
+                                        f: unsafe fn(usize, StackPointer)) -> Option<Box<Box<Any + Send>>> {
+  // Catch any attempts to unwind out of the context.
+  match panic::catch_unwind(move || f(arg, sp)) {
+    Ok(_) => None,
+    Err(err) => {
+      // If the unwinding is due to an UnwindMarker, check whether it is intended
+      // for us by comparing the stack base of the caller with ours. If it is the
+      // same then we can swallow the exception and return to the caller normally.
+      if let Some(marker) = err.downcast_ref::<UnwindMarker>() {
+        if marker.stack_base == stack_base {
+          return None;
+        }
+      }
+
+      // Otherwise, propagate the panic to the parent context.
+      if have_cross_stack_unwind() {
+        panic::resume_unwind(err)
+      } else {
+        // The assembly code will call start_unwind in the parent context and
+        // pass it this Box as parameter.
+        Some(Box::new(err))
+      }
+    }
+  }
+}
+
+// Called by asm to start unwinding in the current context with the given
+// exception object.
+pub unsafe extern "C" fn start_unwind(panic: Box<Box<Any + Send>>) -> ! {
+  // Use resume_unwind instead of panic! to avoid printing a message.
+  panic::resume_unwind(*panic)
+}
+
+// Get the initial argument to pass to start_unwind, keyed to the base address
+// of the generator stack that is going to be unwound.
+#[inline]
+pub fn unwind_arg(stack_base: *mut u8) -> usize {
+  let marker = UnwindMarker {
+    stack_base: stack_base
+  };
+  Box::into_raw(Box::new(Box::new(marker) as Box<Any + Send>)) as usize
+}

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -68,7 +68,7 @@ fn panic_safety() {
 
 #[test]
 fn with_slice_stack() {
-  let mut memory = [0; 1024];
+  let mut memory = [0; 16384];
   let stack = SliceStack::new(&mut memory);
   let mut add_one = unsafe { Generator::unsafe_new(stack, add_one_fn) };
   assert_eq!(add_one.resume(1), Some(2));
@@ -77,7 +77,7 @@ fn with_slice_stack() {
 
 #[test]
 fn with_owned_stack() {
-  let stack = OwnedStack::new(1024);
+  let stack = OwnedStack::new(16384);
   let mut add_one = unsafe { Generator::unsafe_new(stack, add_one_fn) };
   assert_eq!(add_one.resume(1), Some(2));
   assert_eq!(add_one.resume(2), Some(3));


### PR DESCRIPTION
This is actually required to ensure safety. Currently the following safe code causes a segfault: https://gist.github.com/Amanieu/9f4854c096fa519f046ace876779be60

Based on top of #51 
