### PR TITLE
No swap() inline

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -167,7 +167,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   sp
 }
 
-#[inline(always)]
+//#[inline(always)]
 pub unsafe fn swap(arg: usize, new_sp: StackPointer,
                    new_stack: Option<&Stack>) -> (usize, StackPointer) {
   // Address of the topmost CFA stack slot.


### PR DESCRIPTION
This seems to have fixed the relocation troubles that occur when building a dso with libfringe.
