### PR TITLE
Made Yielder constructor public. 

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -194,7 +194,7 @@ pub struct Yielder<Input, Output> {
 }
 
 impl<Input, Output> Yielder<Input, Output> {
-  fn new(stack_ptr: StackPointer) -> Yielder<Input, Output> {
+  pub fn new(stack_ptr: StackPointer) -> Yielder<Input, Output> {
     Yielder {
       stack_ptr: Cell::new(stack_ptr),
       phantom: PhantomData


### PR DESCRIPTION
This helps for building co-routines on top of libfringe